### PR TITLE
fix: handle unpaginated response for accounts and categories

### DIFF
--- a/src/pages/accounts/AccountsPage.jsx
+++ b/src/pages/accounts/AccountsPage.jsx
@@ -31,7 +31,7 @@ export default function AccountsPage() {
       const response = await axios.get('/accounts/', {
         headers: { Authorization: `Bearer ${auth?.access}` },
       });
-      setAccounts(response.data.results);
+      setAccounts(response.data.results ?? response.data);
     } catch (err) {
       console.error('Failed to fetch accounts:', err);
       setError('Failed to load accounts. Please try again.');

--- a/src/pages/accounts/TransferForm.jsx
+++ b/src/pages/accounts/TransferForm.jsx
@@ -25,7 +25,7 @@ export default function TransferForm({ onSuccess, onCancel, initialAccountId = n
         const response = await axios.get('/accounts/', {
           headers: { Authorization: `Bearer ${auth?.access}` },
         });
-        setAccounts(response.data.results);
+        setAccounts(response.data.results ?? response.data);
       } catch (err) {
         console.error('Failed to fetch accounts for transfer:', err);
         setError('Failed to load accounts. Please try again.');

--- a/src/pages/categories/CategoriesPage.jsx
+++ b/src/pages/categories/CategoriesPage.jsx
@@ -36,7 +36,7 @@ export default function CategoriesPage() {
       const response = await axios.get('/categories/', {
         headers: { Authorization: `Bearer ${auth?.access}` },
       });
-      setCategories(response.data.results);
+      setCategories(response.data.results ?? response.data);
     } catch (err) {
       console.error('Failed to fetch categories:', err);
       setError('Failed to load categories. Please try again.');

--- a/src/pages/expenses/AddTransactionForm.jsx
+++ b/src/pages/expenses/AddTransactionForm.jsx
@@ -33,7 +33,7 @@ export default function AddTransactionForm({ onSuccess, onCancel, initialAccount
         const response = await axios.get('/accounts/', {
           headers: { Authorization: `Bearer ${auth?.access}` },
         });
-        setAccounts(response.data.results);
+        setAccounts(response.data.results ?? response.data);
       } catch (err) {
         console.error('Failed to fetch accounts:', err);
         setError('Failed to load accounts for transactions.');
@@ -55,7 +55,7 @@ export default function AddTransactionForm({ onSuccess, onCancel, initialAccount
         const response = await axios.get('/categories/', {
           headers: { Authorization: `Bearer ${auth?.access}` },
         });
-        setCategories(response.data.results.map(cat => ({ value: cat.id, label: cat.name })));
+        setCategories((response.data.results ?? response.data).map(cat => ({ value: cat.id, label: cat.name })));
       } catch (err) {
         console.error('Failed to fetch categories:', err);
         setError('Failed to load categories.');

--- a/src/pages/reports/ReportPage.jsx
+++ b/src/pages/reports/ReportPage.jsx
@@ -58,8 +58,8 @@ export default function ReportPage() {
         axios.get('/accounts/', { headers: { Authorization: `Bearer ${auth?.access}` } }),
         axios.get('/categories/', { headers: { Authorization: `Bearer ${auth?.access}` } }),
       ]);
-      setAccountsOptions(accountsRes.data.results.map(acc => ({ value: acc.id, label: acc.name })));
-      setCategoriesOptions(categoriesRes.data.results.map(cat => ({ value: cat.id, label: cat.name })));
+      setAccountsOptions((accountsRes.data.results ?? accountsRes.data).map(acc => ({ value: acc.id, label: acc.name })));
+      setCategoriesOptions((categoriesRes.data.results ?? categoriesRes.data).map(cat => ({ value: cat.id, label: cat.name })));
     } catch (err) {
       console.error('Failed to fetch filter options:', err);
       setOptionsError('Failed to load filter options.');


### PR DESCRIPTION
## Summary
Defensive fix — all `/accounts/` and `/categories/` fetches now use `results ?? data` so they work regardless of whether DRF returns a paginated envelope or a plain array.

Affected pages: AddTransactionForm, AccountsPage, TransferForm, CategoriesPage, ReportPage

🤖 Generated with [Claude Code](https://claude.com/claude-code)