### PR TITLE
fix: guard against undefined accounts in dashboard and top-up

### DIFF
--- a/src/pages/dashboard/AccountSummary.jsx
+++ b/src/pages/dashboard/AccountSummary.jsx
@@ -22,7 +22,8 @@ export default function AccountSummary({ currency }) {
         const response = await axios.get('/accounts/', {
           headers: { Authorization: `Bearer ${auth?.access}` },
         });
-        setAccounts(response.data.results);
+        const data = Array.isArray(response.data) ? response.data : (response.data?.results || []);
+        setAccounts(data);
       } catch (err) {
         console.error('Failed to fetch accounts for summary:', err);
         setError('Failed to load accounts. Please try again.');

--- a/src/pages/expenses/TopUpForm.jsx
+++ b/src/pages/expenses/TopUpForm.jsx
@@ -31,7 +31,8 @@ export default function TopUpForm({ onSuccess, onCancel, initialAccountId = null
         const response = await axios.get('/accounts/', {
           headers: { Authorization: `Bearer ${auth?.access}` },
         });
-        setAccounts(response.data.results);
+        const data = Array.isArray(response.data) ? response.data : (response.data?.results || []);
+        setAccounts(data);
       } catch (err) {
         console.error('Failed to fetch accounts:', err);
         setError('Failed to load accounts for top-up.');


### PR DESCRIPTION
## Summary
- Dashboard was crashing right after login with `Cannot read properties of undefined (reading 'length')`.
- Root cause: `AccountSummary.jsx` and `TopUpForm.jsx` did `setAccounts(response.data.results)`, but `/api/accounts/` has `pagination_class = None` on the backend and returns a plain array, so `.results` was `undefined`.
- Both now handle either shape: `Array.isArray(res.data) ? res.data : (res.data?.results || [])`.

## Test plan
- [ ] Log in and load `/dashboard` — no crash, totals render
- [ ] Open the Top Up modal — account dropdown populates
- [ ] Verify with an account list that happens to be empty (new user) — empty state renders, no crash